### PR TITLE
Feature install ckanext-ndp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ build-run:
 	docker build ./jhub/spawn_image -t jhub-spawn
 	docker compose -f $(COMPOSE_FILE) up --build -d
 
+install-ckanext-ndp:
+	git -C ./src_extensions clone git@github.com:national-data-platform/ckanext-ndp.git
+	docker restart ndp-ckan-1
+
+update-ckan-config:
+	docker exec -it ndp-ckan-1 /bin/bash -c "ckan config-tool /srv/app/ckan.ini ckanext.ndp.jupyterhub_endpoint=http://localhost:8000"
+
 restart:
 	docker compose -f $(COMPOSE_FILE) up -d --no-deps
 

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ build-run:
 	docker build ./jhub/spawn_image -t jhub-spawn
 	docker compose -f $(COMPOSE_FILE) up --build -d
 
-install-ckanext-ndp:
+download-ckanext-ndp:
 	git -C ./src_extensions clone git@github.com:national-data-platform/ckanext-ndp.git
-	docker restart ndp-ckan-1
 
 update-ckan-config:
-	docker exec -it ndp-ckan-1 /bin/bash -c "ckan config-tool /srv/app/ckan.ini ckanext.ndp.jupyterhub_endpoint=http://localhost:8000"
+	docker compose -f $(COMPOSE_FILE) exec -it ckan /bin/bash -c "ckan config-tool /srv/app/ckan.ini 'ckan.plugins=envvars image_view text_view recline_view datastore datapusher ndp'"
+	docker compose -f $(COMPOSE_FILE) exec -it ckan /bin/bash -c "ckan config-tool /srv/app/ckan.ini ckanext.ndp.jupyterhub_endpoint=http://localhost:8000"
 
 restart:
 	docker compose -f $(COMPOSE_FILE) up -d --no-deps

--- a/README.md
+++ b/README.md
@@ -45,15 +45,10 @@ make dist-clean
 ## CKAN NDP Extension
 Install [ndp ckan extension](https://github.com/national-data-platform/ckanext-ndp):
 ```
-make install-ckanext-ndp
+make download-ckanext-ndp
 ```
 
-Note that the `.env` file needs to be updated with the ndp plugin:
-```
-CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher ndp"
-```
-
-Update ckan config to add Jupyterhub endpoint:
+Install extension and update ckan config to add Jupyterhub endpoint:
 ```
 make update-ckan-config
 ```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ Cleanup and delete volumes:
 ```
 make dist-clean
 ```
+
+## CKAN NDP Extension
+Install [ndp ckan extension](https://github.com/national-data-platform/ckanext-ndp):
+```
+make install-ckanext-ndp
+```
+
+Note that the `.env` file needs to be updated with the ndp plugin:
+```
+CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher ndp"
+```
+
+Update ckan config to add Jupyterhub endpoint:
+```
+make update-ckan-config
+```

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -15,6 +15,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    volumes:
+      - ckan_storage:/var/lib/ckan
+      - ./src_extensions:/srv/app/src_extensions
     entrypoint: ["bash","/srv/app/start_ckan_development.sh"]
 
   datapusher:


### PR DESCRIPTION
Add a way how to install the ckan ndp extension. It is meant for development so that we also have the source code to make modifications if needed.