### PR TITLE
Add harvester tasks to supervisord

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -22,6 +22,8 @@ services:
       - ckan_storage:/var/lib/ckan
       - ./src_extensions:/srv/app/src_extensions
       # - ./ckan.ini:/srv/app/ckan.ini
+      - ./logs:/srv/app/logs
+      - ./supervisord/ckan_harvesting.conf:/etc/supervisord.d/ckan_harvesting.conf
     restart: always
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]

--- a/supervisord/ckan_harvesting.conf
+++ b/supervisord/ckan_harvesting.conf
@@ -1,0 +1,44 @@
+; ===============================
+; ckan harvester
+; ===============================
+
+[program:ckan_gather_consumer]
+
+command=/usr/bin/ckan -c /srv/app/ckan.ini harvester gather-consumer
+; user that owns virtual environment.
+user=ckan
+
+numprocs=1
+stdout_logfile=/srv/app/logs/gather_consumer.log
+stderr_logfile=/srv/app/logs/gather_consumer.log
+autostart=true
+autorestart=true
+startsecs=10
+
+[program:ckan_fetch_consumer]
+
+command=/usr/bin/ckan -c /srv/app/ckan.ini harvester fetch-consumer
+
+; user that owns virtual environment.
+user=ckan
+
+numprocs=1
+stdout_logfile=/srv/app/logs/fetch_consumer.log
+stderr_logfile=/srv/app/logs/fetch_consumer.log
+autostart=true
+autorestart=true
+startsecs=10
+
+[program:ckan_run_harvester]
+
+command=bash -c 'sleep 900 && /usr/bin/ckan -c /srv/app/ckan.ini harvester run'
+
+; user that owns virtual environment.
+user=ckan
+
+numprocs=1
+stdout_logfile=/srv/app/logs/harvester_run.log
+stderr_logfile=/srv/app/logs/harvester_run.log
+autostart=true
+autorestart=true
+startsecs=10


### PR DESCRIPTION
1. Adds `fetch-consumer`, `gather-consumer`, and `run` harvester tasks to supervisord.
2. logs directory is mounted for persistence